### PR TITLE
Fix the order in SchemaPointer returned by SelfSyntaxChecker

### DIFF
--- a/modules/core/src/main/scala/com.snowplowanalytics/iglu.schemaddl/jsonschema/JsonPath.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics/iglu.schemaddl/jsonschema/JsonPath.scala
@@ -87,7 +87,7 @@ object JsonPath {
     }
 
     // If at some point it had unexpected non-schema field - turn downstream into data-pointers
-    val output = Pointer.SchemaPointer(result.reverse)
+    val output = Pointer.SchemaPointer(result)
     Either.cond(isFull, output, output)
   }
 

--- a/modules/core/src/main/scala/com.snowplowanalytics/iglu.schemaddl/jsonschema/SelfSyntaxChecker.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics/iglu.schemaddl/jsonschema/SelfSyntaxChecker.scala
@@ -33,7 +33,7 @@ import io.circe.Json
 import com.snowplowanalytics.iglu.schemaddl.jsonschema.Linter.Message
 
 /**
- * Linting self-describing schemas gainst their meta-schemas
+ * Linting self-describing schemas against their meta-schemas
  * Useful mostly for identifying user-defined properties at a wrong level
  * and unexpected validation types, i.e. `maxLength: "foo"`
  */


### PR DESCRIPTION
[This test](https://github.com/snowplow-incubator/iglu-server/blob/feature/sql-where/src/test/scala/com/snowplowanalytics/iglu/server/service/ValidationServiceSpec.scala#L270) now passes