### PR TITLE
Bump jackson-databind to 2.13.2.1

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,6 @@ object Dependencies {
   object V {
     // Scala
     val igluCore         = "1.1.0"
-    val igluCoreJson4s   = "1.0.0"
     val circe            = "0.14.1"
     val circeJackson     = "0.14.0"
     val jsonValidator    = "1.0.39"
@@ -33,7 +32,7 @@ object Dependencies {
 
   object Libraries {
     // Scala
-    val igluCoreJson4s   = "com.snowplowanalytics"      %% "iglu-core-json4s"       % V.igluCoreJson4s
+    val igluCoreJson4s   = "com.snowplowanalytics"      %% "iglu-core-json4s"       % V.igluCore
     val igluCoreCirce    = "com.snowplowanalytics"      %% "iglu-core-circe"        % V.igluCore
     val circeGeneric     = "io.circe"                   %% "circe-generic"          % V.circe
     val circeJackson     = "io.circe"                   %% "circe-jackson210"       % V.circeJackson

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
     val igluCore         = "1.1.0"
     val circe            = "0.14.2"
     val circeJackson     = "0.14.0"
-    val jsonValidator    = "1.0.39"
+    val jsonValidator    = "1.0.72"
     val catsParse        = "0.3.4"
     val libCompat        = "2.5.0"
     val jacksonDatabind  = "2.13.2.1"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -24,7 +24,7 @@ object Dependencies {
     val jsonValidator    = "1.0.39"
     val catsParse        = "0.3.4"
     val libCompat        = "2.5.0"
-    val jacksonDatabind  = "2.10.5.1"
+    val jacksonDatabind  = "2.13.2.1"
 
     // Scala (test only)
     val specs2           = "4.12.3"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,7 +22,7 @@ object Dependencies {
     val circeJackson     = "0.14.0"
     val jsonValidator    = "1.0.72"
     val catsParse        = "0.3.8"
-    val libCompat        = "2.5.0"
+    val libCompat        = "2.8.1"
     val jacksonDatabind  = "2.13.2.1"
 
     // Scala (test only)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
   object V {
     // Scala
     val igluCore         = "1.1.0"
-    val circe            = "0.14.1"
+    val circe            = "0.14.2"
     val circeJackson     = "0.14.0"
     val jsonValidator    = "1.0.39"
     val catsParse        = "0.3.4"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,7 +26,7 @@ object Dependencies {
     val jacksonDatabind  = "2.13.2.1"
 
     // Scala (test only)
-    val specs2           = "4.12.3"
+    val specs2           = "4.15.0"
     val scalaCheck       = "1.14.0"
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -27,7 +27,7 @@ object Dependencies {
 
     // Scala (test only)
     val specs2           = "4.15.0"
-    val scalaCheck       = "1.14.0"
+    val scalaCheck       = "1.16.0"
   }
 
   object Libraries {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,7 +21,7 @@ object Dependencies {
     val circe            = "0.14.2"
     val circeJackson     = "0.14.0"
     val jsonValidator    = "1.0.72"
-    val catsParse        = "0.3.4"
+    val catsParse        = "0.3.8"
     val libCompat        = "2.5.0"
     val jacksonDatabind  = "2.13.2.1"
 


### PR DESCRIPTION
Before bump:

```
snyk test
```

> ✗ Denial of Service (DoS) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244] in com.fasterxml.jackson.core:jackson-databind@2.10.5.1
    introduced by (...) > com.fasterxml.jackson.core:jackson-databind@2.10.5.1 and 6 other path(s)
  This issue was fixed in versions: 2.12.6.1, 2.13.2.1

After bump:

```
snyk test
```

> ✔ Tested 36 dependencies for known issues, no vulnerable paths found.