### PR TITLE
Parquet : Changing non-null to nullable (and vice versa) should yield nullable

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 0.17.1 (2023-03-08)
+---------------------------
+Parquet : Changing non-null to nullable (and vice versa) should yield nullable (#151) 
+
 Version 0.17.0 (2023-01-12)
 ---------------------------
 Update license to 2023 (#147)

--- a/modules/core/src/main/scala/com.snowplowanalytics/iglu.schemaddl/parquet/Migrations.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics/iglu.schemaddl/parquet/Migrations.scala
@@ -115,10 +115,10 @@ object Migrations {
           case Type.Array(targetElement, targetNullability) =>
             val mergedNullable = if (sourceNullability.nullable & targetNullability.required) {
               migrations += RequiredNullable("[arrayDown]" :: path)
-              Type.Nullability.Required
+              Type.Nullability.Nullable
             } else if (sourceNullability.required & targetNullability.nullable) {
               migrations += NullableRequired("[arrayDown]" :: path)
-              Type.Nullability.Required
+              Type.Nullability.Nullable
             } else if (sourceNullability.required & targetNullability.required) {
               Type.Nullability.Required
             } else {
@@ -148,10 +148,10 @@ object Migrations {
         }
         val mergedNullability: Type.Nullability = if (sourceField.nullability.nullable & targetField.nullability.required) {
           migrations += RequiredNullable(path)
-          Type.Nullability.Required
+          Type.Nullability.Nullable
         } else if (sourceField.nullability.required & targetField.nullability.nullable) {
           migrations += NullableRequired(path)
-          Type.Nullability.Required
+          Type.Nullability.Nullable
         } else if (sourceField.nullability.required & targetField.nullability.required) {
           Type.Nullability.Required
         } else {

--- a/modules/core/src/test/scala/com/snowplowanalytics/iglu/schemaddl/parquet/MigrationSpec.scala
+++ b/modules/core/src/test/scala/com/snowplowanalytics/iglu/schemaddl/parquet/MigrationSpec.scala
@@ -428,7 +428,7 @@ class MigrationSpec extends org.specs2.Specification {
       """.stripMargin)
     val schema2 = Field.build("top", input2, enforceValuePresence = false)
 
-    Migrations.mergeSchemas(schema1, schema2).leftMap(_.toString) should beRight(schema2) and (
+    Migrations.mergeSchemas(schema1, schema2).leftMap(_.toString) should beRight(schema1) and (
       Migrations.assessSchemaMigration(schema1, schema2).map(_.toString) shouldEqual Set(
         "Changing nullable property to required at /arrayKey/[arrayDown]/nestedKey2"
       ))


### PR DESCRIPTION
Fixing bug in parquet migrations.