### PR TITLE
BigQuery final type suggestion should always allow null (close #153)

### DIFF
--- a/modules/core/src/main/scala/com.snowplowanalytics/iglu.schemaddl/bigquery/Field.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics/iglu.schemaddl/bigquery/Field.scala
@@ -42,27 +42,27 @@ object Field {
       case Some(types) if types.possiblyWithNull(CommonProperties.Type.Object) =>
         val subfields = topSchema.properties.map(_.value).getOrElse(Map.empty)
         if (subfields.isEmpty) {
-          Suggestion.finalSuggestion(topSchema, required)(name)
+          Suggestion.finalSuggestion(topSchema, required && !types.nullable)(name)
         } else {
           val requiredKeys = topSchema.required.toList.flatMap(_.value)
           val fields = subfields.map { case (key, schema) =>
             build(key, schema, requiredKeys.contains(key))
           }
           val subFields = fields.toList.sortBy(field => (Mode.sort(field.mode), field.name))
-          Field(name, Type.Record(subFields), Mode.required(required))
+          Field(name, Type.Record(subFields), Mode.required(required && !types.nullable))
         }
       case Some(types) if types.possiblyWithNull(CommonProperties.Type.Array) =>
         topSchema.items match {
           case Some(ArrayProperty.Items.ListItems(schema)) =>
             build(name, schema, false).copy(mode = Mode.Repeated)
           case _ =>
-            Suggestion.finalSuggestion(topSchema, required)(name)
+            Suggestion.finalSuggestion(topSchema, required && !types.nullable)(name)
         }
       case _ =>
         Suggestion.suggestions
           .find(suggestion => suggestion(topSchema, required).isDefined)
           .flatMap(_.apply(topSchema, required))
-          .getOrElse(Suggestion.finalSuggestion(topSchema, required))
+          .getOrElse(Suggestion.finalSuggestion(topSchema, required = false))
           .apply(name)
     }
   }


### PR DESCRIPTION
Whoever reviews this, please confirm my thinking that this is safe to merge for Snowplow's BigQuery loader.  My thinking is this....

If a column was created in BigQuery _before_ this fix, then the column is "mode=required" instead of "mode=nullable".  After this is merged, the loader will attempt to push null values at those columns.  BigQuery will reject the row, and Snowplow will handle it as a failed event.

But.... any such an event would also fail to get loaded without this patch -- it would fail at parse time, instead of at load time.  So I think this patch cannot make things any worse for existing tables.