### PR TITLE
Omit parquet field for a schema with no nested fields

### DIFF
--- a/modules/core/src/main/scala/com.snowplowanalytics/iglu.schemaddl/parquet/Caster.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics/iglu.schemaddl/parquet/Caster.scala
@@ -14,7 +14,7 @@ package com.snowplowanalytics.iglu.schemaddl.parquet
 
 import io.circe._
 import cats.implicits._
-import cats.data.{ValidatedNel, Validated}
+import cats.data.{NonEmptyList, ValidatedNel, Validated}
 import cats.Semigroup
 
 import java.time.{Instant, LocalDate}
@@ -33,7 +33,7 @@ trait Caster[A] {
   def decimalValue(unscaled: BigInt, details: Type.Decimal): A
   def dateValue(v: LocalDate): A
   def timestampValue(v: Instant): A
-  def structValue(vs: List[Caster.NamedValue[A]]): A
+  def structValue(vs: NonEmptyList[Caster.NamedValue[A]]): A
   def arrayValue(vs: List[A]): A
 }
 

--- a/modules/core/src/main/scala/com.snowplowanalytics/iglu.schemaddl/parquet/Field.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics/iglu.schemaddl/parquet/Field.scala
@@ -12,7 +12,7 @@
  */
 package com.snowplowanalytics.iglu.schemaddl.parquet
 
-import cats.data.NonEmptyList
+import cats.data.NonEmptyVector
 import cats.implicits._
 
 import com.snowplowanalytics.iglu.schemaddl.StringUtils
@@ -54,7 +54,7 @@ object Field {
     field.copy(name = normalizeName(field), fieldType = fieldType)
   }
 
-  private def collapseDuplicateFields(normFields: NonEmptyList[Field]): NonEmptyList[Field] = {
+  private def collapseDuplicateFields(normFields: NonEmptyVector[Field]): NonEmptyVector[Field] = {
     val endMap = normFields
       .groupBy(_.name)
       .map { case (key, fs) =>
@@ -137,10 +137,10 @@ object Field {
         val nullability = isFieldNullable(constructedType.nullability, isSubfieldRequired)
         Field(key, constructedType.value, nullability)
       }
-      .toList
+      .toVector
       .sortBy(_.name)
 
-    NonEmptyList.fromList(subfields) match {
+    NonEmptyVector.fromVector(subfields) match {
       case Some(nel) =>
         Some(Type.Struct(nel))
       case None =>

--- a/modules/core/src/main/scala/com.snowplowanalytics/iglu.schemaddl/parquet/FieldValue.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics/iglu.schemaddl/parquet/FieldValue.scala
@@ -13,6 +13,7 @@
 package com.snowplowanalytics.iglu.schemaddl.parquet
 
 import io.circe._
+import cats.data.NonEmptyList
 
 import java.time.{Instant, LocalDate}
 
@@ -49,9 +50,9 @@ object FieldValue {
       DecimalValue(BigDecimal(unscaled, details.scale), details.precision)
     def dateValue(v: LocalDate): FieldValue = DateValue(java.sql.Date.valueOf(v))
     def timestampValue(v: Instant): FieldValue = TimestampValue(java.sql.Timestamp.from(v))
-    def structValue(vs: List[Caster.NamedValue[FieldValue]]): FieldValue =
+    def structValue(vs: NonEmptyList[Caster.NamedValue[FieldValue]]): FieldValue =
       StructValue {
-        vs.map {
+        vs.toList.map {
           case Caster.NamedValue(n, v) => NamedValue(n, v)
         }
       }

--- a/modules/core/src/main/scala/com.snowplowanalytics/iglu.schemaddl/parquet/FieldValue.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics/iglu.schemaddl/parquet/FieldValue.scala
@@ -13,7 +13,7 @@
 package com.snowplowanalytics.iglu.schemaddl.parquet
 
 import io.circe._
-import cats.data.NonEmptyList
+import cats.data.NonEmptyVector
 
 import java.time.{Instant, LocalDate}
 
@@ -33,8 +33,8 @@ object FieldValue {
   case class DecimalValue(value: BigDecimal, precision: Type.DecimalPrecision) extends FieldValue
   case class TimestampValue(value: java.sql.Timestamp) extends FieldValue
   case class DateValue(value: java.sql.Date) extends FieldValue
-  case class StructValue(values: List[NamedValue]) extends FieldValue
-  case class ArrayValue(values: List[FieldValue]) extends FieldValue
+  case class StructValue(values: Vector[NamedValue]) extends FieldValue
+  case class ArrayValue(values: Vector[FieldValue]) extends FieldValue
   /* Part of [[StructValue]] */
   case class NamedValue(name: String, value: FieldValue)
 
@@ -50,13 +50,13 @@ object FieldValue {
       DecimalValue(BigDecimal(unscaled, details.scale), details.precision)
     def dateValue(v: LocalDate): FieldValue = DateValue(java.sql.Date.valueOf(v))
     def timestampValue(v: Instant): FieldValue = TimestampValue(java.sql.Timestamp.from(v))
-    def structValue(vs: NonEmptyList[Caster.NamedValue[FieldValue]]): FieldValue =
+    def structValue(vs: NonEmptyVector[Caster.NamedValue[FieldValue]]): FieldValue =
       StructValue {
-        vs.toList.map {
+        vs.toVector.map {
           case Caster.NamedValue(n, v) => NamedValue(n, v)
         }
       }
-    def arrayValue(vs: List[FieldValue]): FieldValue = ArrayValue(vs)
+    def arrayValue(vs: Vector[FieldValue]): FieldValue = ArrayValue(vs)
   }
 
   /**

--- a/modules/core/src/main/scala/com.snowplowanalytics/iglu.schemaddl/parquet/Type.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics/iglu.schemaddl/parquet/Type.scala
@@ -13,6 +13,7 @@
 package com.snowplowanalytics.iglu.schemaddl.parquet
 
 import cats.Eq
+import cats.data.NonEmptyList
 
 sealed trait Type extends Product with Serializable
 
@@ -26,7 +27,7 @@ object Type {
   case class Decimal(precision: DecimalPrecision, scale: Int) extends Type 
   case object Date extends Type 
   case object Timestamp extends Type 
-  case class Struct(fields: List[Field]) extends Type 
+  case class Struct(fields: NonEmptyList[Field]) extends Type 
   case class Array(element: Type, nullability: Nullability) extends Type
 
   /* Fallback type for when json schema does not map to a parquet primitive type (e.g. unions)

--- a/modules/core/src/main/scala/com.snowplowanalytics/iglu.schemaddl/parquet/Type.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics/iglu.schemaddl/parquet/Type.scala
@@ -13,7 +13,7 @@
 package com.snowplowanalytics.iglu.schemaddl.parquet
 
 import cats.Eq
-import cats.data.NonEmptyList
+import cats.data.NonEmptyVector
 
 sealed trait Type extends Product with Serializable
 
@@ -27,7 +27,7 @@ object Type {
   case class Decimal(precision: DecimalPrecision, scale: Int) extends Type 
   case object Date extends Type 
   case object Timestamp extends Type 
-  case class Struct(fields: NonEmptyList[Field]) extends Type 
+  case class Struct(fields: NonEmptyVector[Field]) extends Type 
   case class Array(element: Type, nullability: Nullability) extends Type
 
   /* Fallback type for when json schema does not map to a parquet primitive type (e.g. unions)

--- a/modules/core/src/test/scala/com/snowplowanalytics/iglu/schemaddl/jsonschema/mutate/MutateSpec.scala
+++ b/modules/core/src/test/scala/com/snowplowanalytics/iglu/schemaddl/jsonschema/mutate/MutateSpec.scala
@@ -17,7 +17,7 @@ import com.snowplowanalytics.iglu.schemaddl.SpecHelpers
 class MutateSpec extends org.specs2.Specification {
 
   def is = s2"""
-    forStorage should not make any changes to a simpe schema $common1
+    forStorage should not make any changes to a simple schema $common1
     forStorage should merge oneOf string/number into a union type $common2
     forStorage should merge oneOf enums into an extended enum $common3
     forStorage should merge anyOf string/number into a union type $common4
@@ -386,8 +386,7 @@ class MutateSpec extends org.specs2.Specification {
     val expected = SpecHelpers.parseSchema(
       """
         |{
-        |"type": "object",
-        |"additionalProperties": false
+        |"type": "object"
         |}
       """.stripMargin)
     Mutate.forStorage(input) must_== expected

--- a/modules/core/src/test/scala/com/snowplowanalytics/iglu/schemaddl/parquet/CasterSpec.scala
+++ b/modules/core/src/test/scala/com/snowplowanalytics/iglu/schemaddl/parquet/CasterSpec.scala
@@ -87,7 +87,7 @@ class CasterSpec extends org.specs2.Specification { def is = s2"""
 
   def e5 = {
     val inputJson = json"""{"foo": 42, "bar": true}"""
-    val inputField = Type.Struct(List(
+    val inputField = Type.Struct(NonEmptyList.of(
       Field("foo", Type.Integer, Nullable),
       Field("bar", Type.Boolean, Required)))
     
@@ -100,7 +100,7 @@ class CasterSpec extends org.specs2.Specification { def is = s2"""
 
   def e6 = {
     val inputJson = json"""{"bar": true}"""
-    val inputField = Type.Struct(List(
+    val inputField = Type.Struct(NonEmptyList.of(
       Field("foo", Type.Integer, Nullable),
       Field("bar", Type.Boolean, Required)))
     
@@ -135,7 +135,7 @@ class CasterSpec extends org.specs2.Specification { def is = s2"""
         "undefined": 42
       }"""
 
-    val inputField = Type.Struct(List(
+    val inputField = Type.Struct(NonEmptyList.of(
       Field("someBool", Type.Boolean, Required),
       Field("repeatedInt", Type.Array(Type.Integer, Required), Required)))
 
@@ -158,13 +158,13 @@ class CasterSpec extends org.specs2.Specification { def is = s2"""
         }
       }"""
 
-    val inputField = Type.Struct(List(
+    val inputField = Type.Struct(NonEmptyList.of(
       Field("someBool", Type.Boolean, Required),
-      Field("nested", Type.Struct(List(
+      Field("nested", Type.Struct(NonEmptyList.of(
         Field("str", Type.String, Required),
         Field("int", Type.Integer, Nullable),
-        Field("deep", Type.Struct(List(Field("str", Type.String, Nullable))), Required),
-        Field("arr", Type.Array(Type.Struct(List(Field("a", Type.String, Required))), Required), Required)
+        Field("deep", Type.Struct(NonEmptyList.of(Field("str", Type.String, Nullable))), Required),
+        Field("arr", Type.Array(Type.Struct(NonEmptyList.of(Field("a", Type.String, Required))), Required), Required)
       )), Nullable)
     ))
 
@@ -190,7 +190,7 @@ class CasterSpec extends org.specs2.Specification { def is = s2"""
         "optional": null
       }"""
 
-    val inputField = Type.Struct(List(Field("optional", Type.String, Nullable)))
+    val inputField = Type.Struct(NonEmptyList.of(Field("optional", Type.String, Nullable)))
 
     val expected = StructValue(List(
       NamedValue("optional", NullValue)
@@ -204,7 +204,7 @@ class CasterSpec extends org.specs2.Specification { def is = s2"""
         "unionType": ["this", "is", "fallback", "strategy"]
       }"""
 
-    val inputField = Type.Struct(List(Field("unionType", Type.Json, Nullable)))
+    val inputField = Type.Struct(NonEmptyList.of(Field("unionType", Type.Json, Nullable)))
 
     val expected = StructValue(List(
       NamedValue("union_type", JsonValue(json"""["this","is","fallback","strategy"]"""))
@@ -269,7 +269,7 @@ class CasterSpec extends org.specs2.Specification { def is = s2"""
   }
 
   def e16 = {
-    val inputField = Type.Struct(List(
+    val inputField = Type.Struct(NonEmptyList.of(
       Field("xyz", Type.Integer, Nullable, Set("xyz", "XYZ"))))
 
     List(
@@ -288,7 +288,7 @@ class CasterSpec extends org.specs2.Specification { def is = s2"""
 
   def e17 = {
     val inputJson = json"""[{"id":  null}]"""
-    val fieldType = Type.Array(Type.Struct(List(Field("id", Type.String, Required, Set("id")))), Required)
+    val fieldType = Type.Array(Type.Struct(NonEmptyList.of(Field("id", Type.String, Required, Set("id")))), Required)
 
     val expected = NonEmptyList.one(WrongType(Json.Null, Type.String))
     Caster.cast(caster, Field("top", fieldType, Nullable), inputJson) must beInvalid(expected)

--- a/modules/core/src/test/scala/com/snowplowanalytics/iglu/schemaddl/parquet/ExampleFieldValue.scala
+++ b/modules/core/src/test/scala/com/snowplowanalytics/iglu/schemaddl/parquet/ExampleFieldValue.scala
@@ -13,7 +13,7 @@
 package com.snowplowanalytics.iglu.schemaddl.parquet
 
 import io.circe.Json
-import cats.data.NonEmptyList
+import cats.data.NonEmptyVector
 
 import java.time.{LocalDate, Instant}
 
@@ -31,8 +31,8 @@ object ExampleFieldValue {
   case class DecimalValue(value: BigDecimal, precision: Type.DecimalPrecision) extends ExampleFieldValue
   case class TimestampValue(value: java.sql.Timestamp) extends ExampleFieldValue
   case class DateValue(value: java.sql.Date) extends ExampleFieldValue
-  case class StructValue(values: List[Caster.NamedValue[ExampleFieldValue]]) extends ExampleFieldValue
-  case class ArrayValue(values: List[ExampleFieldValue]) extends ExampleFieldValue
+  case class StructValue(values: Vector[Caster.NamedValue[ExampleFieldValue]]) extends ExampleFieldValue
+  case class ArrayValue(values: Vector[ExampleFieldValue]) extends ExampleFieldValue
 
   val caster: Caster[ExampleFieldValue] = new Caster[ExampleFieldValue] {
     def nullValue: ExampleFieldValue = NullValue
@@ -46,7 +46,7 @@ object ExampleFieldValue {
       DecimalValue(BigDecimal(unscaled, details.scale), details.precision)
     def dateValue(v: LocalDate): ExampleFieldValue = DateValue(java.sql.Date.valueOf(v))
     def timestampValue(v: Instant): ExampleFieldValue = TimestampValue(java.sql.Timestamp.from(v))
-    def structValue(vs: NonEmptyList[Caster.NamedValue[ExampleFieldValue]]): ExampleFieldValue = StructValue(vs.toList)
-    def arrayValue(vs: List[ExampleFieldValue]): ExampleFieldValue = ArrayValue(vs)
+    def structValue(vs: NonEmptyVector[Caster.NamedValue[ExampleFieldValue]]): ExampleFieldValue = StructValue(vs.toVector)
+    def arrayValue(vs: Vector[ExampleFieldValue]): ExampleFieldValue = ArrayValue(vs)
   }
 }

--- a/modules/core/src/test/scala/com/snowplowanalytics/iglu/schemaddl/parquet/ExampleFieldValue.scala
+++ b/modules/core/src/test/scala/com/snowplowanalytics/iglu/schemaddl/parquet/ExampleFieldValue.scala
@@ -13,6 +13,7 @@
 package com.snowplowanalytics.iglu.schemaddl.parquet
 
 import io.circe.Json
+import cats.data.NonEmptyList
 
 import java.time.{LocalDate, Instant}
 
@@ -45,7 +46,7 @@ object ExampleFieldValue {
       DecimalValue(BigDecimal(unscaled, details.scale), details.precision)
     def dateValue(v: LocalDate): ExampleFieldValue = DateValue(java.sql.Date.valueOf(v))
     def timestampValue(v: Instant): ExampleFieldValue = TimestampValue(java.sql.Timestamp.from(v))
-    def structValue(vs: List[Caster.NamedValue[ExampleFieldValue]]): ExampleFieldValue = StructValue(vs)
+    def structValue(vs: NonEmptyList[Caster.NamedValue[ExampleFieldValue]]): ExampleFieldValue = StructValue(vs.toList)
     def arrayValue(vs: List[ExampleFieldValue]): ExampleFieldValue = ArrayValue(vs)
   }
 }

--- a/modules/core/src/test/scala/com/snowplowanalytics/iglu/schemaddl/parquet/FieldSpec.scala
+++ b/modules/core/src/test/scala/com/snowplowanalytics/iglu/schemaddl/parquet/FieldSpec.scala
@@ -12,7 +12,7 @@
  */
 package com.snowplowanalytics.iglu.schemaddl.parquet
 
-import cats.data.NonEmptyList
+import cats.data.NonEmptyVector
 
 import com.snowplowanalytics.iglu.schemaddl.SpecHelpers
 import com.snowplowanalytics.iglu.schemaddl.jsonschema.Schema
@@ -72,12 +72,12 @@ class FieldSpec extends org.specs2.Specification { def is = s2"""
       """.stripMargin)
 
     val expected =
-      Type.Struct(NonEmptyList.of(
+      Type.Struct(NonEmptyVector.of(
         Field(
           name = "objectKey",
           nullability = Nullable,
           fieldType = Type.Struct(
-            NonEmptyList.of(
+            NonEmptyVector.of(
               Field("nestedKey1", Type.String,  nullability = Nullable),
               Field("nestedKey2", Type.Long,    nullability = Nullable),
               Field("nestedKey3", Type.Boolean, nullability = Required),
@@ -107,7 +107,7 @@ class FieldSpec extends org.specs2.Specification { def is = s2"""
 
     val expected =
       Type.Struct(
-        NonEmptyList.of(
+        NonEmptyVector.of(
           Field("numeric1", Type.Double, nullability = Nullable),
           Field("numeric2", Type.Long,   nullability = Required),
           Field("numeric3", Type.Double, nullability = Nullable),
@@ -134,7 +134,7 @@ class FieldSpec extends org.specs2.Specification { def is = s2"""
 
     val expected =
       Type.Array(
-        element = Type.Struct(NonEmptyList.of(
+        element = Type.Struct(NonEmptyVector.of(
           Field("bar", Type.Long,   nullability = Nullable),
           Field("foo", Type.String, nullability = Nullable)
         )),
@@ -160,7 +160,7 @@ class FieldSpec extends org.specs2.Specification { def is = s2"""
 
     val expected =
       Type.Array(
-        element = Type.Struct(NonEmptyList.of(
+        element = Type.Struct(NonEmptyVector.of(
           Field("bar", Type.Long,   nullability = Nullable),
           Field("foo", Type.String, nullability = Nullable)
         )),
@@ -183,7 +183,7 @@ class FieldSpec extends org.specs2.Specification { def is = s2"""
 
     val expected =
       Type.Struct(
-        fields = NonEmptyList.of(
+        fields = NonEmptyVector.of(
           Field(
             name = "union",
             fieldType = Type.Json,
@@ -224,7 +224,7 @@ class FieldSpec extends org.specs2.Specification { def is = s2"""
 
     val expected =
       Type.Struct(
-        fields = NonEmptyList.of(
+        fields = NonEmptyVector.of(
           Field(
             name = "union",
             fieldType = Type.Json,
@@ -252,7 +252,7 @@ class FieldSpec extends org.specs2.Specification { def is = s2"""
 
     val expected =
       Type.Struct(
-        fields = NonEmptyList.of(
+        fields = NonEmptyVector.of(
           Field(
             name = "imp",
             fieldType = Type.Array(Type.Json, Nullable),
@@ -280,7 +280,7 @@ class FieldSpec extends org.specs2.Specification { def is = s2"""
 
     val expected =
       Type.Struct(
-        fields = NonEmptyList.of(
+        fields = NonEmptyVector.of(
           Field(
             name = "imp",
             fieldType = Type.Array(Type.Boolean, Required),
@@ -330,12 +330,12 @@ class FieldSpec extends org.specs2.Specification { def is = s2"""
       """.stripMargin)
 
     val expected =
-      Type.Struct(NonEmptyList.of(
+      Type.Struct(NonEmptyVector.of(
         Field(
           name = "objectKey",
           nullability = Nullable,
           fieldType = Type.Struct(
-            NonEmptyList.of(
+            NonEmptyVector.of(
               Field("nestedKey1", Type.String,  nullability = Nullable)
             )
           )
@@ -386,7 +386,7 @@ class FieldSpec extends org.specs2.Specification { def is = s2"""
     Field.normalize(Field(
       name = "top",
       fieldType = Type.Struct(
-        fields = NonEmptyList.of(
+        fields = NonEmptyVector.of(
           Field(
             name = "_ga",
             fieldType = Type.Integer,
@@ -407,7 +407,7 @@ class FieldSpec extends org.specs2.Specification { def is = s2"""
       nullability = Nullable)) must equalTo(Field(
       name = "top",
       fieldType = Type.Struct(
-        fields = NonEmptyList.of(
+        fields = NonEmptyVector.of(
           Field(
             name = "_ga",
             fieldType = Type.Integer,
@@ -425,7 +425,7 @@ class FieldSpec extends org.specs2.Specification { def is = s2"""
   }
 
   def e15 = {
-    val fields = NonEmptyList.of(
+    val fields = NonEmptyVector.of(
       Field(
         name = "xyz",
         fieldType = Type.Integer,
@@ -444,7 +444,7 @@ class FieldSpec extends org.specs2.Specification { def is = s2"""
     val expected = Field(
       name = "top",
       fieldType = Type.Struct(
-        fields = NonEmptyList.of(
+        fields = NonEmptyVector.of(
           Field(
             name = "xyz",
             fieldType = Type.String,

--- a/modules/core/src/test/scala/com/snowplowanalytics/iglu/schemaddl/parquet/FieldSpec.scala
+++ b/modules/core/src/test/scala/com/snowplowanalytics/iglu/schemaddl/parquet/FieldSpec.scala
@@ -12,6 +12,8 @@
  */
 package com.snowplowanalytics.iglu.schemaddl.parquet
 
+import cats.data.NonEmptyList
+
 import com.snowplowanalytics.iglu.schemaddl.SpecHelpers
 import com.snowplowanalytics.iglu.schemaddl.jsonschema.Schema
 import com.snowplowanalytics.iglu.schemaddl.parquet.Type.Nullability.{Nullable, Required}
@@ -24,24 +26,27 @@ class FieldSpec extends org.specs2.Specification { def is = s2"""
   build generates repeated field for array $e3
   build generates repeated nullary field for array $e4
   build uses json-fallback strategy for union types $e5
-  build uses json-fallback strategy for empty object $e6
+  build uses json-fallback strategy for empty object allowing additional properties $e6
   build recognized nullable union type $e7
   build generates repeated string for empty schema in items $e8
   build generates repeated record for nullable array $e9
-  normalName handles camel case and disallowed characters $e10
-  normalize would collapse colliding names $e11
-  normalize would collapse colliding names with deterministic type selection $e12
+  build returns nothing for empty object disallowing additional properties $e10
+  build ignores nested field if it is an empty object disallowing additional properties $e11
+  build returns nothing if the only nested field is an empty object disallowing additional properties $e12
+  normalName handles camel case and disallowed characters $e13
+  normalize would collapse colliding names $e14
+  normalize would collapse colliding names with deterministic type selection $e15
   """
 
   // a helper
-  def testBuild(input: Schema, expected: Type): MatchResult[Field] =
+  def testBuild(input: Schema, expected: Type): MatchResult[Option[Field]] =
     List(
-      Field.build("top", input, false) must beEqualTo(Field("top", expected, Nullable)),
-      Field.build("top", input, true) must beEqualTo(Field("top", expected, Required)),
-      Field.buildRepeated("top", input, true, Nullable) must beEqualTo(Field("top", Type.Array(expected, Required), Nullable)),
-      Field.buildRepeated("top", input, true, Required) must beEqualTo(Field("top", Type.Array(expected, Required), Required)),
-      Field.buildRepeated("top", input, false, Nullable) must beEqualTo(Field("top", Type.Array(expected, Nullable), Nullable)),
-      Field.buildRepeated("top", input, false, Required) must beEqualTo(Field("top", Type.Array(expected, Nullable), Required)),
+      Field.build("top", input, false) must beSome(beEqualTo(Field("top", expected, Nullable))),
+      Field.build("top", input, true) must beSome(beEqualTo(Field("top", expected, Required))),
+      Field.buildRepeated("top", input, true, Nullable) must beSome(beEqualTo(Field("top", Type.Array(expected, Required), Nullable))),
+      Field.buildRepeated("top", input, true, Required) must beSome(beEqualTo(Field("top", Type.Array(expected, Required), Required))),
+      Field.buildRepeated("top", input, false, Nullable) must beSome(beEqualTo(Field("top", Type.Array(expected, Nullable), Nullable))),
+      Field.buildRepeated("top", input, false, Required) must beSome(beEqualTo(Field("top", Type.Array(expected, Nullable), Required))),
     ).reduce(_ and _)
 
   def e1 = {
@@ -67,14 +72,14 @@ class FieldSpec extends org.specs2.Specification { def is = s2"""
       """.stripMargin)
 
     val expected =
-      Type.Struct(List(
+      Type.Struct(NonEmptyList.of(
         Field(
           name = "objectKey",
           nullability = Nullable,
           fieldType = Type.Struct(
-            List(
-              Field("nestedKey1", Type.String,  nullability = Nullable), 
-              Field("nestedKey2", Type.Long,    nullability = Nullable), 
+            NonEmptyList.of(
+              Field("nestedKey1", Type.String,  nullability = Nullable),
+              Field("nestedKey2", Type.Long,    nullability = Nullable),
               Field("nestedKey3", Type.Boolean, nullability = Required),
             )
           ),
@@ -102,9 +107,9 @@ class FieldSpec extends org.specs2.Specification { def is = s2"""
 
     val expected =
       Type.Struct(
-        List(
+        NonEmptyList.of(
           Field("numeric1", Type.Double, nullability = Nullable),
-          Field("numeric2", Type.Long,   nullability = Required), 
+          Field("numeric2", Type.Long,   nullability = Required),
           Field("numeric3", Type.Double, nullability = Nullable),
           Field("numeric4", Type.Double, nullability = Nullable)
         )
@@ -129,7 +134,7 @@ class FieldSpec extends org.specs2.Specification { def is = s2"""
 
     val expected =
       Type.Array(
-        element = Type.Struct(List(
+        element = Type.Struct(NonEmptyList.of(
           Field("bar", Type.Long,   nullability = Nullable),
           Field("foo", Type.String, nullability = Nullable)
         )),
@@ -155,7 +160,7 @@ class FieldSpec extends org.specs2.Specification { def is = s2"""
 
     val expected =
       Type.Array(
-        element = Type.Struct(List(
+        element = Type.Struct(NonEmptyList.of(
           Field("bar", Type.Long,   nullability = Nullable),
           Field("foo", Type.String, nullability = Nullable)
         )),
@@ -178,7 +183,7 @@ class FieldSpec extends org.specs2.Specification { def is = s2"""
 
     val expected =
       Type.Struct(
-        fields = List(
+        fields = NonEmptyList.of(
           Field(
             name = "union",
             fieldType = Type.Json,
@@ -195,7 +200,8 @@ class FieldSpec extends org.specs2.Specification { def is = s2"""
       """
         |{
         |  "type": "object",
-        |  "properties": { }
+        |  "properties": { },
+        |  "additionalProperties": true
         |}
       """.stripMargin)
 
@@ -218,7 +224,7 @@ class FieldSpec extends org.specs2.Specification { def is = s2"""
 
     val expected =
       Type.Struct(
-        fields = List(
+        fields = NonEmptyList.of(
           Field(
             name = "union",
             fieldType = Type.Json,
@@ -246,7 +252,7 @@ class FieldSpec extends org.specs2.Specification { def is = s2"""
 
     val expected =
       Type.Struct(
-        fields = List(
+        fields = NonEmptyList.of(
           Field(
             name = "imp",
             fieldType = Type.Array(Type.Json, Nullable),
@@ -274,7 +280,7 @@ class FieldSpec extends org.specs2.Specification { def is = s2"""
 
     val expected =
       Type.Struct(
-        fields = List(
+        fields = NonEmptyList.of(
           Field(
             name = "imp",
             fieldType = Type.Array(Type.Boolean, Required),
@@ -287,23 +293,100 @@ class FieldSpec extends org.specs2.Specification { def is = s2"""
   }
 
   def e10 = {
+    val input = SpecHelpers.parseSchema(
+      """
+        |{
+        |  "type": "object",
+        |  "properties": { },
+        |  "additionalProperties": false
+        |}
+      """.stripMargin)
+
+    List(
+      Field.build("top", input, false) must beNone,
+      Field.build("top", input, true) must beNone,
+      Field.buildRepeated("top", input, true, Nullable) must beNone,
+      Field.buildRepeated("top", input, true, Required) must beNone,
+      Field.buildRepeated("top", input, false, Nullable) must beNone,
+      Field.buildRepeated("top", input, false, Required) must beNone
+    ).reduce(_ and _)
+  }
+
+
+  def e11 = {
+    val input = SpecHelpers.parseSchema(
+      """
+        |{"type": "object",
+        |"properties": {
+        |  "objectKey": {
+        |    "type": "object",
+        |    "properties": {
+        |      "nestedKey1": { "type": "string" },
+        |      "shouldBeRemoved": { "type": "object", "additionalProperties": false }
+        |    }
+        |  }
+        |}
+        |}
+      """.stripMargin)
+
+    val expected =
+      Type.Struct(NonEmptyList.of(
+        Field(
+          name = "objectKey",
+          nullability = Nullable,
+          fieldType = Type.Struct(
+            NonEmptyList.of(
+              Field("nestedKey1", Type.String,  nullability = Nullable)
+            )
+          )
+        )
+      ))
+
+    testBuild(input, expected)
+  }
+
+  def e12 = {
+    val input = SpecHelpers.parseSchema(
+      """
+        |{"type": "object",
+        |"properties": {
+        |  "objectKey": {
+        |    "type": "object",
+        |    "properties": {
+        |      "shouldBeRemoved": { "type": "object", "additionalProperties": false }
+        |    }
+        |  }
+        |}
+        |}
+      """.stripMargin)
+    List(
+      Field.build("top", input, false) must beNone,
+      Field.build("top", input, true) must beNone,
+      Field.buildRepeated("top", input, true, Nullable) must beNone,
+      Field.buildRepeated("top", input, true, Required) must beNone,
+      Field.buildRepeated("top", input, false, Nullable) must beNone,
+      Field.buildRepeated("top", input, false, Required) must beNone
+    ).reduce(_ and _)
+  }
+
+  def e13 = {
     (fieldNormalName("") must beEqualTo("")) and
       (fieldNormalName("test1") must beEqualTo("test1")) and
       (fieldNormalName("test1Test2Test3") must beEqualTo("test1_test2_test3")) and
       (fieldNormalName("Test1Test2TEST3") must beEqualTo("test1_test2_test3")) and
       (fieldNormalName("test1,test2.test3;test4") must beEqualTo("test1_test2_test3_test4")) and
-      (fieldNormalName("1test1,test2.test3;test4") must beEqualTo("1test1_test2_test3_test4")) and 
+      (fieldNormalName("1test1,test2.test3;test4") must beEqualTo("1test1_test2_test3_test4")) and
       (fieldNormalName("_50test1,test2.test3;test4") must beEqualTo("_50test1_test2_test3_test4")) and
       (fieldNormalName("_.test1,test2.test3;test4") must beEqualTo("__test1_test2_test3_test4")) and
       (fieldNormalName(",.;:") must beEqualTo("____")) and
-      (fieldNormalName("1test1,Test2Test3Test4.test5;test6") must beEqualTo("1test1_test2_test3_test4_test5_test6")) 
+      (fieldNormalName("1test1,Test2Test3Test4.test5;test6") must beEqualTo("1test1_test2_test3_test4_test5_test6"))
   }
 
-  def e11 = {
+  def e14 = {
     Field.normalize(Field(
       name = "top",
       fieldType = Type.Struct(
-        fields = List(
+        fields = NonEmptyList.of(
           Field(
             name = "_ga",
             fieldType = Type.Integer,
@@ -324,7 +407,7 @@ class FieldSpec extends org.specs2.Specification { def is = s2"""
       nullability = Nullable)) must equalTo(Field(
       name = "top",
       fieldType = Type.Struct(
-        fields = List(
+        fields = NonEmptyList.of(
           Field(
             name = "_ga",
             fieldType = Type.Integer,
@@ -341,8 +424,8 @@ class FieldSpec extends org.specs2.Specification { def is = s2"""
       nullability = Nullable))
   }
 
-  def e12 = {
-    val fields = List(
+  def e15 = {
+    val fields = NonEmptyList.of(
       Field(
         name = "xyz",
         fieldType = Type.Integer,
@@ -361,7 +444,7 @@ class FieldSpec extends org.specs2.Specification { def is = s2"""
     val expected = Field(
       name = "top",
       fieldType = Type.Struct(
-        fields = List(
+        fields = NonEmptyList.of(
           Field(
             name = "xyz",
             fieldType = Type.String,

--- a/modules/core/src/test/scala/com/snowplowanalytics/iglu/schemaddl/parquet/MigrationSpec.scala
+++ b/modules/core/src/test/scala/com/snowplowanalytics/iglu/schemaddl/parquet/MigrationSpec.scala
@@ -60,7 +60,7 @@ class MigrationSpec extends org.specs2.Specification {
         |}
         |}
       """.stripMargin)
-    val schema2 = Field.build("top", input2, enforceValuePresence = false)
+    val schema2 = Field.build("top", input2, enforceValuePresence = false).get
     Migrations.mergeSchemas(leanBase, schema2) should beRight(schema2) and (
       Migrations.assessSchemaMigration(leanBase, schema2).map(_.toString) shouldEqual Set("Schema key addition at /objectKey/string2Key")
       )
@@ -87,7 +87,7 @@ class MigrationSpec extends org.specs2.Specification {
         |}
         |}
       """.stripMargin)
-    val schema2 = Field.build("top", input2, enforceValuePresence = false)
+    val schema2 = Field.build("top", input2, enforceValuePresence = false).get
     Migrations.mergeSchemas(leanBase, schema2).leftMap(_.map(_.toString)) should beLeft(List("Incompatible type change String to Long at /objectKey/nestedKey1")) and (
       Migrations.assessSchemaMigration(leanBase, schema2).map(_.toString) shouldEqual Set("Incompatible type change String to Long at /objectKey/nestedKey1")
       )
@@ -113,8 +113,7 @@ class MigrationSpec extends org.specs2.Specification {
         |}
         |}
       """.stripMargin)
-    val schema2 = Field.build("top", input2, enforceValuePresence = false)
-    
+    val schema2 = Field.build("top", input2, enforceValuePresence = false).get
 
     Migrations.mergeSchemas(leanBase, schema2) should beRight(leanBase) and (
       Migrations.assessSchemaMigration(leanBase, schema2).map(_.toString) shouldEqual Set("Key removal at /objectKey/nestedKey3"))
@@ -145,7 +144,7 @@ class MigrationSpec extends org.specs2.Specification {
         |}
         |}
       """.stripMargin)
-    val schema2 = Field.build("top", input2, enforceValuePresence = false)
+    val schema2 = Field.build("top", input2, enforceValuePresence = false).get
     Migrations.mergeSchemas(leanBase, schema2) should beRight(schema2) and (
       Migrations.assessSchemaMigration(leanBase, schema2).map(_.toString) shouldEqual Set("Schema key addition at /string2Key")
       )
@@ -171,7 +170,7 @@ class MigrationSpec extends org.specs2.Specification {
         |}
         |}
       """.stripMargin)
-    val schema2 = Field.build("top", input2, enforceValuePresence = false)
+    val schema2 = Field.build("top", input2, enforceValuePresence = false).get
     Migrations.mergeSchemas(leanBase, schema2).leftMap(_.toString) should beLeft(Set("Incompatible type change String to Long at /stringKey"))
     Migrations.assessSchemaMigration(leanBase, schema2).map(_.toString) shouldEqual Set("Incompatible type change String to Long at /stringKey")
   }
@@ -193,7 +192,7 @@ class MigrationSpec extends org.specs2.Specification {
         |}
         |}
       """.stripMargin)
-    val schema2 = Field.build("top", input2, enforceValuePresence = false)
+    val schema2 = Field.build("top", input2, enforceValuePresence = false).get
     Migrations.mergeSchemas(leanBase, schema2) should beRight(leanBase) and (
       Migrations.assessSchemaMigration(leanBase, schema2).map(_.toString) shouldEqual Set("Key removal at /stringKey"))
   }
@@ -213,7 +212,7 @@ class MigrationSpec extends org.specs2.Specification {
         |}
         |}
       """.stripMargin)
-    val schema1 = Field.build("top", input1, enforceValuePresence = false)
+    val schema1 = Field.build("top", input1, enforceValuePresence = false).get
 
     val input2 = SpecHelpers.parseSchema(
       """
@@ -228,7 +227,7 @@ class MigrationSpec extends org.specs2.Specification {
         |}
         |}
       """.stripMargin)
-    val schema2 = Field.build("top", input2, enforceValuePresence = false)
+    val schema2 = Field.build("top", input2, enforceValuePresence = false).get
 
     Migrations.mergeSchemas(schema1, schema2).leftMap(_.map(_.toString)) should beLeft(List(
       "Incompatible type change Long to String at /arrayKey/[arrayDown]"
@@ -258,7 +257,7 @@ class MigrationSpec extends org.specs2.Specification {
         |}
         |}
       """.stripMargin)
-    val schema1 = Field.build("top", input1, enforceValuePresence = false)
+    val schema1 = Field.build("top", input1, enforceValuePresence = false).get
 
     val input2 = SpecHelpers.parseSchema(
       """
@@ -278,7 +277,7 @@ class MigrationSpec extends org.specs2.Specification {
         |}
         |}
       """.stripMargin)
-    val schema2 = Field.build("top", input2, enforceValuePresence = false)
+    val schema2 = Field.build("top", input2, enforceValuePresence = false).get
 
     Migrations.mergeSchemas(schema1, schema2).leftMap(_.toString) should beRight(schema2) and (
       Migrations.assessSchemaMigration(schema1, schema2).map(_.toString) shouldEqual
@@ -305,7 +304,7 @@ class MigrationSpec extends org.specs2.Specification {
         |}
         |}
       """.stripMargin)
-    val schema1 = Field.build("top", input1, enforceValuePresence = false)
+    val schema1 = Field.build("top", input1, enforceValuePresence = false).get
 
     val input2 = SpecHelpers.parseSchema(
       """
@@ -325,7 +324,7 @@ class MigrationSpec extends org.specs2.Specification {
         |}
         |}
       """.stripMargin)
-    val schema2 = Field.build("top", input2, enforceValuePresence = false)
+    val schema2 = Field.build("top", input2, enforceValuePresence = false).get
 
     Migrations.mergeSchemas(schema2, schema1).leftMap(_.toString) should beRight(schema2) and (
       Migrations.assessSchemaMigration(schema2, schema1).map(_.toString) shouldEqual
@@ -352,7 +351,7 @@ class MigrationSpec extends org.specs2.Specification {
         |}
         |}
       """.stripMargin)
-    val schema1 = Field.build("top", input1, enforceValuePresence = false)
+    val schema1 = Field.build("top", input1, enforceValuePresence = false).get
 
     val input2 = SpecHelpers.parseSchema(
       """
@@ -371,7 +370,7 @@ class MigrationSpec extends org.specs2.Specification {
         |}
         |}
       """.stripMargin)
-    val schema2 = Field.build("top", input2, enforceValuePresence = false)
+    val schema2 = Field.build("top", input2, enforceValuePresence = false).get
 
     Migrations.mergeSchemas(schema1, schema2).leftMap(_.map(_.toString)) should beLeft(List(
       "Incompatible type change String to Long at /arrayKey/[arrayDown]/nestedKey1"
@@ -400,7 +399,7 @@ class MigrationSpec extends org.specs2.Specification {
         |}
         |}
       """.stripMargin)
-    val schema1 = Field.build("top", input1, enforceValuePresence = false)
+    val schema1 = Field.build("top", input1, enforceValuePresence = false).get
 
     val input2 = SpecHelpers.parseSchema(
       """
@@ -420,7 +419,7 @@ class MigrationSpec extends org.specs2.Specification {
         |}
         |}
       """.stripMargin)
-    val schema2 = Field.build("top", input2, enforceValuePresence = false)
+    val schema2 = Field.build("top", input2, enforceValuePresence = false).get
 
     Migrations.mergeSchemas(schema1, schema2).leftMap(_.toString) should beRight(schema1) and (
       Migrations.assessSchemaMigration(schema1, schema2).map(_.toString) shouldEqual Set(
@@ -460,7 +459,7 @@ class MigrationSpec extends org.specs2.Specification {
         |}
         |}
       """.stripMargin)
-    val schema1 = Field.build("top", input1, enforceValuePresence = false)
+    val schema1 = Field.build("top", input1, enforceValuePresence = false).get
 
     val input2 = SpecHelpers.parseSchema(
       """
@@ -493,7 +492,7 @@ class MigrationSpec extends org.specs2.Specification {
         |}
         |}
       """.stripMargin)
-    val schema2 = Field.build("top", input2, enforceValuePresence = false)
+    val schema2 = Field.build("top", input2, enforceValuePresence = false).get
 
     Migrations.mergeSchemas(schema1, schema2).leftMap(_.toString) should beRight(schema2) and (
       Migrations.assessSchemaMigration(schema1, schema2).map(_.toString) shouldEqual Set(
@@ -519,7 +518,7 @@ class MigrationSpec extends org.specs2.Specification {
         |}
         |}
       """.stripMargin)
-    val schema1 = Field.normalize(Field.build("top", input1, enforceValuePresence = false))
+    val schema1 = Field.normalize(Field.build("top", input1, enforceValuePresence = false).get)
 
     val input2 = SpecHelpers.parseSchema(
       """
@@ -529,7 +528,7 @@ class MigrationSpec extends org.specs2.Specification {
         |}
         |}
           """.stripMargin)
-    val schema2 =  Field.normalize(Field.build("top", input2, enforceValuePresence = false))
+    val schema2 =  Field.normalize(Field.build("top", input2, enforceValuePresence = false).get)
 
     Migrations.mergeSchemas(schema1, schema2).map(
       f => f.fieldType.asInstanceOf[Struct].fields.head.accessors.mkString(",")
@@ -546,7 +545,7 @@ class MigrationSpec extends org.specs2.Specification {
         |"required" : ["k1"]
         |}
     """.stripMargin)
-    val schema1 = Field.normalize(Field.build("top", input1, enforceValuePresence = false))
+    val schema1 = Field.normalize(Field.build("top", input1, enforceValuePresence = false).get)
 
     val input2 = SpecHelpers.parseSchema(
       """
@@ -556,7 +555,7 @@ class MigrationSpec extends org.specs2.Specification {
         |}
         |}
         """.stripMargin)
-    val schema2 = Field.normalize(Field.build("top", input2, enforceValuePresence = false))
+    val schema2 = Field.normalize(Field.build("top", input2, enforceValuePresence = false).get)
 
     Migrations.mergeSchemas(schema1, schema2).map(
       f => f.fieldType.asInstanceOf[Struct].fields.last.nullability.nullable
@@ -573,7 +572,7 @@ class MigrationSpec extends org.specs2.Specification {
         |}
         |}
     """.stripMargin)
-    val schema1 = Field.normalize(Field.build("top", input1, enforceValuePresence = false))
+    val schema1 = Field.normalize(Field.build("top", input1, enforceValuePresence = false).get)
 
     val input2 = SpecHelpers.parseSchema(
       """
@@ -584,7 +583,7 @@ class MigrationSpec extends org.specs2.Specification {
         |  "required" : ["k2"]
         |}
         """.stripMargin)
-    val schema2 = Field.normalize(Field.build("top", input2, enforceValuePresence = false))
+    val schema2 = Field.normalize(Field.build("top", input2, enforceValuePresence = false).get)
 
     Migrations.mergeSchemas(schema1, schema2).map(
       f => f.fieldType.asInstanceOf[Struct].fields.forall(_.nullability.nullable)
@@ -612,5 +611,5 @@ object MigrationSpec {
       |  }
       |}
       |}
-      """.stripMargin), enforceValuePresence = false)
+      """.stripMargin), enforceValuePresence = false).get
 }


### PR DESCRIPTION
Snowplow users commonly use schemas with no nested fields. Previously, we were creating a string column and loading the string field `{}`. But there is no benefit to loading this redundant data.

By omitting a column for these schemas, it means we support schema evolution if the user ever adds a nested field to the empty schema.

For empty schemas with `additionalProperties: true` we retain the old behaviour of loading the original JSON as a string.