### PR TITLE
Use JSON column type.

### DIFF
--- a/modules/core/src/main/scala/com.snowplowanalytics/iglu.schemaddl/bigquery/Suggestion.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics/iglu.schemaddl/bigquery/Suggestion.scala
@@ -85,9 +85,9 @@ object Suggestion {
   def finalSuggestion(schema: Schema, required: Boolean): String => Field =
     schema.`type` match {
       case Some(jsonType) if jsonType.nullable =>
-        name => Field(name, Type.String, Mode.Nullable)
+        name => Field(name, Type.Json, Mode.Nullable)
       case _ =>
-        name => Field(name, Type.String, Mode.required(required))
+        name => Field(name, Type.Json, Mode.required(required))
     }
 
   val suggestions: List[Suggestion] = List(

--- a/modules/core/src/main/scala/com.snowplowanalytics/iglu.schemaddl/bigquery/Type.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics/iglu.schemaddl/bigquery/Type.scala
@@ -24,6 +24,6 @@ object Type {
   case object Date extends Type
   case object DateTime extends Type
   case object Timestamp extends Type
+  case object Json extends Type
   case class Record(fields: List[Field]) extends Type
 }
-


### PR DESCRIPTION
This is not tested. I have created this only for discussion at the moment.
Does it make sense to add JSON type? The use case is to allow bigquery stream loader to create a column of type JSON (instead of String) when schema is empty.

please check: https://github.com/snowplow-incubator/snowplow-bigquery-loader/pull/385
